### PR TITLE
Use the temporary package

### DIFF
--- a/external-sort.cabal
+++ b/external-sort.cabal
@@ -21,8 +21,8 @@ library
                      , pipes
                      , pipes-interleave
                      , containers
-                     , unix
                      , directory
+                     , temporary
                      , vector
                      , vector-algorithms
 
@@ -46,7 +46,7 @@ executable sort-tester
                      , criterion
                      , directory
                      , random
-                     , unix
+                     , temporary
                      , external-sort
 
 
@@ -68,7 +68,7 @@ test-suite external-sort-test
                      , pipes
                      , pipes-interleave
                      , random
-                     , unix
+                     , temporary
                      , vector
                      , vector-algorithms
 

--- a/test/SortTester.hs
+++ b/test/SortTester.hs
@@ -21,8 +21,8 @@ main = do
   let numberOfIntsStr:chunkSizeStr:restArgs = args
   putStrLn "Generating random file..."
   withSystemTempDirectory "SortTester" $ \tmpDir -> do
-    inFile  <- genRandomFile (read numberOfIntsStr)
-    outFile <- genOutputFileName
+    inFile  <- genRandomFile tmpDir (read numberOfIntsStr)
+    outFile <- genOutputFileName tmpDir
     withArgs restArgs $
      defaultMain [
        bgroup "sort-tester" [

--- a/test/TestUtil.hs
+++ b/test/TestUtil.hs
@@ -1,20 +1,19 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 module TestUtil where
 
-import           Data.ExternalSort.Internal
+import Data.ExternalSort.Internal
 
 import           Control.Monad
-import qualified Data.Binary as Bin
+import qualified Data.Binary          as Bin
 import qualified Data.ByteString.Lazy as LB
 import           Data.Int
 import           Data.List
 import           System.IO
-import           System.Posix.Temp
 import           System.Random
 
-genRandomFile :: Int -> IO FilePath
-genRandomFile n = do
-  (path, inH) <- mkstemp "unsorted.txt."
+genRandomFile :: FilePath -> Int -> IO FilePath
+genRandomFile tmpDir n = do
+  (path, inH) <- openTempFile tmpDir "unsorted.txt."
   let write = do
         (i :: Int32) <- randomRIO (0,maxBound)
         writeInt32 inH i
@@ -22,15 +21,15 @@ genRandomFile n = do
   hClose inH
   return path
 
-genRandomFileAndOpen :: Int -> IO (FilePath, Handle)
-genRandomFileAndOpen n = do
-  path <- genRandomFile n
+genRandomFileAndOpen :: FilePath -> Int -> IO (FilePath, Handle)
+genRandomFileAndOpen tmpDir n = do
+  path <- genRandomFile tmpDir n
   h <- openFile path ReadMode
   return (path, h)
 
-genOutputFileName :: IO FilePath
-genOutputFileName = do
-  (path, outH) <- mkstemp "sorted.txt."
+genOutputFileName :: FilePath -> IO FilePath
+genOutputFileName tmpDir = do
+  (path, outH) <- openTempFile tmpDir "sorted.txt."
   hClose outH
   return path
 


### PR DESCRIPTION
This way we can create a temporary directory (inside the system
temporary directory so hopefully it's large enough!) for all the
temporary files; when finished the directory will be deleted and so will
the temp files, making it easier to clean up (and no need for an IORef!).
